### PR TITLE
Add admin user to genlab group

### DIFF
--- a/src/fixtures/users.json
+++ b/src/fixtures/users.json
@@ -12,7 +12,7 @@
         "is_staff": true,
         "is_active": true,
         "date_joined": "2023-05-27T08:35:08.845Z",
-        "groups": [],
+        "groups": [1],
         "user_permissions": []
       }
     }


### PR DESCRIPTION
Add admin user to the genlab group so that the staff navigation item is visible in the navigation bar.