### PR TITLE
Able to select samples and sort them before generating genlabIDs.

### DIFF
--- a/src/genlab_bestilling/libs/genlabid.py
+++ b/src/genlab_bestilling/libs/genlabid.py
@@ -61,7 +61,7 @@ def get_current_sequences(order_id):
         return sequences
 
 
-def generate(order_id):
+def generate(order_id, sorting_order=None, selected_samples=None):
     """
     wrapper to handle errors and reset the sequence to the current sequence value
     """
@@ -71,7 +71,9 @@ def generate(order_id):
     with connection.cursor() as cursor:
         try:
             with transaction.atomic():
-                cursor.execute(update_genlab_id_query(order_id))
+                cursor.execute(
+                    update_genlab_id_query(order_id, sorting_order, selected_samples)
+                )
         except Exception:
             # if there is an error, reset the sequence
             # NOTE: this is unsafe unless this function is executed in a queue
@@ -84,16 +86,25 @@ def generate(order_id):
     print(sequences)
 
 
-def update_genlab_id_query(order_id):
+def update_genlab_id_query(order_id, sorting_order=None, selected_samples=None):
     """
     Safe generation of a SQL raw query using sqlglot
     The query runs an update on all the rows with a specific order_id
     and set genlab_id = generate_genlab_id(code, year)
     """
+    if sorting_order is None:
+        sorting_order = []
+
     samples_table = Sample._meta.db_table
     extraction_order_table = ExtractionOrder._meta.db_table
     order_table = Order._meta.db_table
     species_table = Species._meta.db_table
+
+    order_by_columns = (
+        [column(col, table=samples_table) for col in sorting_order]
+        if sorting_order
+        else [column("name", table=samples_table)]
+    )
 
     return sqlglot.expressions.update(
         samples_table,
@@ -185,7 +196,7 @@ def update_genlab_id_query(order_id):
                                 column(col="genlab_id").is_(None),
                             )
                         )
-                        .order_by(column("name", table=samples_table))
+                        .order_by(*order_by_columns)
                     ),
                 ),
                 alias="order_samples",

--- a/src/genlab_bestilling/models.py
+++ b/src/genlab_bestilling/models.py
@@ -451,6 +451,22 @@ class ExtractionOrder(Order):
         self.save()
         app.configure_task(name="generate-genlab-ids").defer(order_id=self.id)
 
+    def order_selected_checked(self, sorting_order=None, selected_samples=None):
+        """
+        Partially set the order as checked by the lab staff, generate a genlab id
+        """
+        self.internal_status = self.Status.CHECKED
+        self.status = self.OrderStatus.PROCESSING
+        self.save()
+
+        selected_sample_names = list(selected_samples.values_list("id", flat=True))
+
+        app.configure_task(name="generate-genlab-ids").defer(
+            order_id=self.id,
+            sorting_order=sorting_order,
+            selected_samples=selected_sample_names,
+        )
+
 
 class AnalysisOrder(Order):
     samples = models.ManyToManyField(

--- a/src/genlab_bestilling/tasks.py
+++ b/src/genlab_bestilling/tasks.py
@@ -12,6 +12,10 @@ from .libs.genlabid import generate as generate_genlab_id
         max_attempts=5, linear_wait=5, retry_exceptions={OperationalError}
     ),
 )
-def generate_ids(order_id):
-    generate_genlab_id(order_id=order_id)
+def generate_ids(order_id, sorting_order=None, selected_samples=None):
+    generate_genlab_id(
+        order_id=order_id,
+        sorting_order=sorting_order,
+        selected_samples=selected_samples,
+    )
     # isolate(order_id=order_id)

--- a/src/staff/templates/staff/base_filter.html
+++ b/src/staff/templates/staff/base_filter.html
@@ -5,19 +5,23 @@
 {% block content %}
     <h3 class="text-4xl mb-5">{% block page-title %}{% endblock page-title %}</h3>
     {% block page-inner %}{% endblock page-inner %}
-
-    <form method="get" class="py-3 px-4 border mb-3 ">
-        <div class="flex flex-wrap gap-4">
-            {{ filter.form | crispy }}
-        </div>
-        <button class="btn bg-primary" type="submit">Search</button>
-    </form>
-
-    {% render_table table %}
 {% endblock %}
 
 {% block body_javascript %}
 {{ block.super }}
 <script type="text/javascript" src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
 {{ filter.form.media }}
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const selectAll = document.getElementById('select-all-checkbox');
+      if (selectAll) {
+        selectAll.addEventListener('change', function () {
+          const checkboxes = document.querySelectorAll('input[name="checked"]');
+          checkboxes.forEach(cb => {
+            cb.checked = selectAll.checked;
+          });
+        });
+      }
+    });
+    </script> 
 {% endblock body_javascript %}

--- a/src/staff/templates/staff/extractionplate_filter.html
+++ b/src/staff/templates/staff/extractionplate_filter.html
@@ -1,4 +1,6 @@
 {% extends "staff/base_filter.html" %}
+{% load crispy_forms_tags static %}
+{% load render_table from django_tables2 %}
 
 {% block page-title %}
 Extraction plates
@@ -8,4 +10,13 @@ Extraction plates
 <div class="flex justify-end my-3">
     <a class="btn bg-primary" href="{% url 'staff:plates-create' %}">Create</a>
 </div>
+
+<form method="get" class="py-3 px-4 border mb-3 ">
+    <div class="flex flex-wrap gap-4">
+        {{ filter.form | crispy }}
+    </div>
+    <button class="btn bg-primary" type="submit">Search</button>
+</form>
+
+{% render_table table %}
 {% endblock page-inner %}

--- a/src/staff/templates/staff/sample_filter.html
+++ b/src/staff/templates/staff/sample_filter.html
@@ -1,14 +1,28 @@
 {% extends "staff/base_filter.html" %}
+{% load crispy_forms_tags static %}
+{% load render_table from django_tables2 %}
 
 {% block page-title %}
 {% if order %}{{ order }} - Samples{% else %}Samples{% endif %}
 {% endblock page-title %}
 
 {% block page-inner %}
+
 {% if order %}
 <div class="flex gap-5 mb-5">
     <a class="btn bg-primary" href="../"><i class="fas fa-arrow-left"></i> back</a>
     <a class="btn bg-yellow-500" href="{% url 'samples-csv' %}?order={{ order.pk }}"><i class="fas fa-download"></i> Download CSV</a>
 </div>
+
+ <form method="post" action="{% url 'staff:generate-genlab-ids' pk=order.pk %}">
+    {% csrf_token %}
+    <input type="hidden" name="sort" value="{{ request.GET.sort|default:'' }}">
+    <button class="btn bg-blue-500 text-white mt-4" type="submit" name="generate_genlab_ids">
+        <i class="fa-solid fa-id-badge"></i> Generate genlab IDs
+    </button>
+
+    {% render_table table %}
+  </form>
+
 {% endif %}
 {% endblock page-inner %}

--- a/src/staff/templates/staff/samplemarkeranalysis_filter.html
+++ b/src/staff/templates/staff/samplemarkeranalysis_filter.html
@@ -1,4 +1,6 @@
 {% extends "staff/base_filter.html" %}
+{% load crispy_forms_tags static %}
+{% load render_table from django_tables2 %}
 
 {% block page-title %}
 {% if order %}{{ order }} - Samples{% else %}Samples{% endif %}
@@ -10,4 +12,13 @@
     <a class="btn bg-primary" href="../"><i class="fas fa-arrow-left"></i> back</a>
 </div>
 {% endif %}
+
+<form method="get" class="py-3 px-4 border mb-3 ">
+    <div class="flex flex-wrap gap-4">
+        {{ filter.form | crispy }}
+    </div>
+    <button class="btn bg-primary" type="submit">Search</button>
+</form>
+
+{% render_table table %}
 {% endblock page-inner %}

--- a/src/staff/urls.py
+++ b/src/staff/urls.py
@@ -11,6 +11,7 @@ from .views import (
     ExtractionPlateCreateView,
     ExtractionPlateDetailView,
     ExtractionPlateListView,
+    GenerateGenlabIDsView,
     ManaullyCheckedOrderActionView,
     OrderAnalysisSamplesListView,
     OrderExtractionSamplesListView,
@@ -72,6 +73,11 @@ urlpatterns = [
         "orders/extraction/<int:pk>/samples/",
         OrderExtractionSamplesListView.as_view(),
         name="order-extraction-samples",
+    ),
+    path(
+        "orders/extraction/<int:pk>/samples/generate-genlab-ids/",
+        GenerateGenlabIDsView.as_view(),
+        name="generate-genlab-ids",
     ),
     path(
         "orders/analysis/<int:pk>/samples/",

--- a/src/staff/views.py
+++ b/src/staff/views.py
@@ -347,6 +347,54 @@ class OrderToNextStatusActionView(SingleObjectMixin, ActionView):
         return HttpResponseRedirect(self.get_success_url())
 
 
+class GenerateGenlabIDsView(
+    SingleObjectMixin, StaffMixin, SingleTableMixin, FilterView
+):
+    model = ExtractionOrder
+
+    def get_object(self):
+        return ExtractionOrder.objects.get(pk=self.kwargs["pk"])
+
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        selected_ids = request.POST.getlist("checked")
+
+        if not selected_ids:
+            messages.error(request, "No samples were selected.")
+            return HttpResponseRedirect(self.get_success_url())
+
+        sort_param = request.POST.get("sort", "")
+        sorting_order = [s.strip() for s in sort_param.split(",") if s.strip()]
+
+        selected_samples = Sample.objects.filter(pk__in=selected_ids)
+
+        if sorting_order:
+            selected_samples = selected_samples.order_by(*sorting_order)
+
+        try:
+            self.object.order_selected_checked(
+                sorting_order=sorting_order, selected_samples=selected_samples
+            )
+            messages.add_message(
+                request,
+                messages.SUCCESS,
+                _(f"Genlab IDs generated for {selected_samples.count()} samples."),
+            )
+        except Exception as e:
+            messages.add_message(
+                request,
+                messages.ERROR,
+                f"Error: {str(e)}",
+            )
+
+        return HttpResponseRedirect(self.get_success_url())
+
+    def get_success_url(self):
+        return reverse_lazy(
+            "staff:order-extraction-samples", kwargs={"pk": self.object.pk}
+        )
+
+
 class ExtractionPlateCreateView(StaffMixin, CreateView):
     model = ExtractionPlate
     form_class = ExtractionPlateForm


### PR DESCRIPTION
- Changes are made to html files to send the post request within the same form.
- Generate now accepts more fields
- Still support for the other buttons that generate genlabIDs
- Javascript is added to make checkboxes dynamic

Has not been tested for genlabID generation, as I a not able to do so locally.