### PR TITLE
Update equipment order information on staff page

### DIFF
--- a/src/genlab_bestilling/templates/genlab_bestilling/equipmentorder_detail.html
+++ b/src/genlab_bestilling/templates/genlab_bestilling/equipmentorder_detail.html
@@ -6,7 +6,7 @@
 {% block content %}
     {% fragment as table_header %}
     {% #table-cell header=True %}Equipment{% /table-cell %}
-    {% #table-cell header=True %}Buffer{% /table-cell %}
+    {% #table-cell header=True %}Buffer/Volume{% /table-cell %}
     {% #table-cell header=True %}Qty{% /table-cell %}
     {% endfragment %}
 

--- a/src/staff/templates/staff/equipmentorder_detail.html
+++ b/src/staff/templates/staff/equipmentorder_detail.html
@@ -5,7 +5,7 @@
 {% block content %}
     {% fragment as table_header %}
     {% #table-cell header=True %}Equipment{% /table-cell %}
-    {% #table-cell header=True %}Unit{% /table-cell %}
+    {% #table-cell header=True %}Buffer/Volume{% /table-cell %}
     {% #table-cell header=True %}Qty{% /table-cell %}
     {% endfragment %}
 
@@ -22,7 +22,7 @@
         {% for oq in object.equipments.all %}
             <tr>
                 {% #table-cell %}{{ oq.equipment.name }}{% /table-cell %}
-                {% #table-cell %}{{ oq.equipment.unit }}{% /table-cell %}
+                {% #table-cell %}{{ oq.buffer.name }} {{ oq.buffer_quantity}} {{ oq.buffer.unit }}{% /table-cell %}
                 {% #table-cell %}{{ oq.quantity }}{% /table-cell %}
             </tr>
         {% empty %}


### PR DESCRIPTION
Requested by Kristin.

Information on the scientists equipment order page and staff equipment order page was not the same. 

Update information on both pages to match.

**Before**:
Scientist page:
![image](https://github.com/user-attachments/assets/48a4241f-da13-4ec4-8f2f-42e477d7b5a0)

Staff page:
![image](https://github.com/user-attachments/assets/cfe3855d-9ee2-4e66-932d-6fc503f103f0)

**After**:
Both pages:
![image](https://github.com/user-attachments/assets/66b7fccb-0d95-4bd9-b513-041b0fcf0355)
