### PR TITLE
Able to select samples and sort them before generating genlabIDs.

### DIFF
--- a/src/genlab_bestilling/models.py
+++ b/src/genlab_bestilling/models.py
@@ -452,6 +452,22 @@ class ExtractionOrder(Order):
         self.save()
         app.configure_task(name="generate-genlab-ids").defer(order_id=self.id)
 
+    def order_selected_checked(self, sorting_order=None, selected_samples=None):
+        """
+        Partially set the order as checked by the lab staff, generate a genlab id
+        """
+        self.internal_status = self.Status.CHECKED
+        self.status = self.OrderStatus.PROCESSING
+        self.save()
+
+        selected_sample_names = list(selected_samples.values_list("id", flat=True))
+
+        app.configure_task(name="generate-genlab-ids").defer(
+            order_id=self.id,
+            sorting_order=sorting_order,
+            selected_samples=selected_sample_names,
+        )
+
 
 class AnalysisOrder(Order):
     samples = models.ManyToManyField(

--- a/src/genlab_bestilling/tasks.py
+++ b/src/genlab_bestilling/tasks.py
@@ -12,6 +12,10 @@ from .libs.genlabid import generate as generate_genlab_id
         max_attempts=5, linear_wait=5, retry_exceptions={OperationalError}
     ),
 )
-def generate_ids(order_id: str | int) -> None:
-    generate_genlab_id(order_id=order_id)
+def generate_ids(order_id, sorting_order=None, selected_samples=None):
+    generate_genlab_id(
+        order_id=order_id,
+        sorting_order=sorting_order,
+        selected_samples=selected_samples,
+    )
     # isolate(order_id=order_id)

--- a/src/staff/tables.py
+++ b/src/staff/tables.py
@@ -1,6 +1,8 @@
 from typing import Any
 
 import django_tables2 as tables
+from django.db.models import IntegerField
+from django.db.models.functions import Cast
 from django.utils.safestring import mark_safe
 
 from genlab_bestilling.models import (
@@ -123,6 +125,16 @@ class SampleBaseTable(tables.Table):
     plate_positions = tables.Column(
         empty_values=(), orderable=False, verbose_name="Extraction position"
     )
+    checked = tables.CheckBoxColumn(
+        attrs={
+            "th__input": {"type": "checkbox", "id": "select-all-checkbox"},
+        },
+        accessor="pk",
+        orderable=False,
+        empty_values=(),
+    )
+
+    name = tables.Column(order_by=("name_as_int",))
 
     class Meta:
         model = Sample
@@ -139,14 +151,26 @@ class SampleBaseTable(tables.Table):
             "plate_positions",
         ]
         attrs = {"class": "w-full table-auto tailwind-table table-sm"}
+        sequence = ("checked",)
 
         empty_text = "No Samples"
 
-    def render_plate_positions(self, value: Any) -> str:
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if hasattr(self.data, "data"):
+            self.data.data = self.data.data.annotate(
+                name_as_int=Cast("name", output_field=IntegerField())
+            )
+
+    def render_plate_positions(self, value):
         if value:
             return ", ".join([str(v) for v in value.all()])
 
         return ""
+
+    def render_checked(self, record):
+        return mark_safe(f'<input type="checkbox" name="checked" value="{record.id}">')
 
 
 class OrderExtractionSampleTable(SampleBaseTable):

--- a/src/staff/templates/staff/base_filter.html
+++ b/src/staff/templates/staff/base_filter.html
@@ -5,19 +5,23 @@
 {% block content %}
     <h3 class="text-4xl mb-5">{% block page-title %}{% endblock page-title %}</h3>
     {% block page-inner %}{% endblock page-inner %}
-
-    <form method="get" class="py-3 px-4 border mb-3 ">
-        <div class="flex flex-wrap gap-4">
-            {{ filter.form | crispy }}
-        </div>
-        <button class="btn bg-primary" type="submit">Search</button>
-    </form>
-
-    {% render_table table %}
 {% endblock %}
 
 {% block body_javascript %}
 {{ block.super }}
 <script type="text/javascript" src="{% static 'admin/js/vendor/jquery/jquery.js' %}"></script>
 {{ filter.form.media }}
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const selectAll = document.getElementById('select-all-checkbox');
+      if (selectAll) {
+        selectAll.addEventListener('change', function () {
+          const checkboxes = document.querySelectorAll('input[name="checked"]');
+          checkboxes.forEach(cb => {
+            cb.checked = selectAll.checked;
+          });
+        });
+      }
+    });
+    </script> 
 {% endblock body_javascript %}

--- a/src/staff/templates/staff/extractionplate_filter.html
+++ b/src/staff/templates/staff/extractionplate_filter.html
@@ -1,4 +1,6 @@
 {% extends "staff/base_filter.html" %}
+{% load crispy_forms_tags static %}
+{% load render_table from django_tables2 %}
 
 {% block page-title %}
 Extraction plates
@@ -8,4 +10,13 @@ Extraction plates
 <div class="flex justify-end my-3">
     <a class="btn bg-primary" href="{% url 'staff:plates-create' %}">Create</a>
 </div>
+
+<form method="get" class="py-3 px-4 border mb-3 ">
+    <div class="flex flex-wrap gap-4">
+        {{ filter.form | crispy }}
+    </div>
+    <button class="btn bg-primary" type="submit">Search</button>
+</form>
+
+{% render_table table %}
 {% endblock page-inner %}

--- a/src/staff/templates/staff/sample_filter.html
+++ b/src/staff/templates/staff/sample_filter.html
@@ -1,14 +1,28 @@
 {% extends "staff/base_filter.html" %}
+{% load crispy_forms_tags static %}
+{% load render_table from django_tables2 %}
 
 {% block page-title %}
 {% if order %}{{ order }} - Samples{% else %}Samples{% endif %}
 {% endblock page-title %}
 
 {% block page-inner %}
+
 {% if order %}
 <div class="flex gap-5 mb-5">
     <a class="btn bg-primary" href="../"><i class="fas fa-arrow-left"></i> back</a>
     <a class="btn bg-yellow-500" href="{% url 'samples-csv' %}?order={{ order.pk }}"><i class="fas fa-download"></i> Download CSV</a>
 </div>
+
+ <form method="post" action="{% url 'staff:generate-genlab-ids' pk=order.pk %}">
+    {% csrf_token %}
+    <input type="hidden" name="sort" value="{{ request.GET.sort|default:'' }}">
+    <button class="btn bg-blue-500 text-white mt-4" type="submit" name="generate_genlab_ids">
+        <i class="fa-solid fa-id-badge"></i> Generate genlab IDs
+    </button>
+
+    {% render_table table %}
+  </form>
+
 {% endif %}
 {% endblock page-inner %}

--- a/src/staff/templates/staff/samplemarkeranalysis_filter.html
+++ b/src/staff/templates/staff/samplemarkeranalysis_filter.html
@@ -1,4 +1,6 @@
 {% extends "staff/base_filter.html" %}
+{% load crispy_forms_tags static %}
+{% load render_table from django_tables2 %}
 
 {% block page-title %}
 {% if order %}{{ order }} - Samples{% else %}Samples{% endif %}
@@ -10,4 +12,13 @@
     <a class="btn bg-primary" href="../"><i class="fas fa-arrow-left"></i> back</a>
 </div>
 {% endif %}
+
+<form method="get" class="py-3 px-4 border mb-3 ">
+    <div class="flex flex-wrap gap-4">
+        {{ filter.form | crispy }}
+    </div>
+    <button class="btn bg-primary" type="submit">Search</button>
+</form>
+
+{% render_table table %}
 {% endblock page-inner %}

--- a/src/staff/urls.py
+++ b/src/staff/urls.py
@@ -11,6 +11,7 @@ from .views import (
     ExtractionPlateCreateView,
     ExtractionPlateDetailView,
     ExtractionPlateListView,
+    GenerateGenlabIDsView,
     ManaullyCheckedOrderActionView,
     OrderAnalysisSamplesListView,
     OrderExtractionSamplesListView,
@@ -72,6 +73,11 @@ urlpatterns = [
         "orders/extraction/<int:pk>/samples/",
         OrderExtractionSamplesListView.as_view(),
         name="order-extraction-samples",
+    ),
+    path(
+        "orders/extraction/<int:pk>/samples/generate-genlab-ids/",
+        GenerateGenlabIDsView.as_view(),
+        name="generate-genlab-ids",
     ),
     path(
         "orders/analysis/<int:pk>/samples/",


### PR DESCRIPTION
- Changes are made to html files to send the post request within the same form.
- Generate now accepts more fields
- Still support for the other buttons that generate genlabIDs
- Javascript is added to make checkboxes dynamic

Has not been tested for genlabID generation, as I a not able to do so locally.