### PR TITLE
177 change total samples to how many is in an order, not a project

### DIFF
--- a/src/staff/tables.py
+++ b/src/staff/tables.py
@@ -53,13 +53,12 @@ class OrderTable(tables.Table):
             "genrequest__name",
             "genrequest__project",
             "genrequest__area",
-            "genrequest__expected_total_samples",
             "genrequest__samples_owner",
             "created_at",
             "last_modified_at",
             "is_urgent",
         ]
-        sequence = ("is_urgent", "status", "id")
+        sequence = ("is_urgent", "status", "id", "name")
         empty_text = "No Orders"
         order_by = ("-is_urgent", "last_modified_at", "created_at")
 
@@ -95,6 +94,12 @@ class ExtractionOrderTable(OrderTable):
         empty_values=(),
     )
 
+    sample_count = tables.Column(
+        accessor="sample_count",
+        verbose_name="Sample Count",
+        orderable=False,
+    )
+
     class Meta(OrderTable.Meta):
         model = ExtractionOrder
         fields = OrderTable.Meta.fields + [
@@ -105,6 +110,10 @@ class ExtractionOrderTable(OrderTable):
             "return_samples",
             "pre_isolated",
         ]
+        sequence = OrderTable.Meta.sequence + ("sample_count",)
+
+    def render_sample_count(self, record: Any) -> str:
+        return record.sample_count or "0"
 
 
 class EquipmentOrderTable(OrderTable):

--- a/src/staff/views.py
+++ b/src/staff/views.py
@@ -4,6 +4,7 @@ from typing import Any
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.db import models
+from django.db.models import Count
 from django.forms import Form
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
@@ -121,6 +122,7 @@ class ExtractionOrderListView(StaffMixin, SingleTableMixin, FilterView):
                 "genrequest__area",
             )
             .prefetch_related("species", "sample_types")
+            .annotate(sample_count=Count("samples"))
         )
 
 


### PR DESCRIPTION
It now shows the number of samples in an order as requested by the staff. 

<img width="1421" alt="Screenshot 2025-07-03 at 09 14 05" src="https://github.com/user-attachments/assets/2175dcec-2fe2-42c3-8d33-c9475506aa9f" />
