### PR TITLE
Add link to related analysis order extraction order

### DIFF
--- a/src/staff/templates/staff/extractionorder_detail.html
+++ b/src/staff/templates/staff/extractionorder_detail.html
@@ -3,30 +3,22 @@
 
 
 {% block content %}
-    {% fragment as table_header %}
-    {% #table-cell header=True %}GUID{% /table-cell %}
-    {% #table-cell header=True %}Type{% /table-cell %}
-    {% #table-cell header=True %}Species{% /table-cell %}
-    {% #table-cell header=True %}Markers{% /table-cell %}
-    {% #table-cell header=True %}Location{% /table-cell %}
-    {% #table-cell header=True %}Date{% /table-cell %}
-    {% #table-cell header=True %}Volume{% /table-cell %}
-    {% endfragment %}
     <h3 class="text-4xl mb-5">Order {{ object }}</h3>
-    <div class="flex gap-5 mb-5">
-    </div>
-
-    {% object-detail object=object %}
-
-
-    <h5 class="text-2xl my-5">Delivered Samples</h5>
-    <div class="bg-white p-4">
-        <p>{{ object.samples.count }} samples were delivered</p>
-    </div>
+    <div class="flex gap-5 mb-5"></div>
 
     <div class="flex gap-5 my-5">
         <a class="btn bg-yellow-200" href="{% url 'staff:order-extraction-list' %}"><i class="fas fa-arrow-left"></i> back</a>
         <a class="btn bg-primary" href="{% url 'staff:order-extraction-samples' pk=object.id %}">Samples</a>
+        {% if analysis_orders|length > 1 %}
+            <select id="analysis-select" class="btn bg-yellow-200" onchange="if(this.value) { window.location.href = this.value; }" style="width: 13rem;">
+            <option value="">Go to Analysis Order</option>
+            {% for ao in analysis_orders %}
+                <option value="{% url 'staff:order-analysis-detail' pk=ao.id %}">{{ ao }}</option>
+            {% endfor %}
+            </select>
+        {% elif analysis_orders|length == 1 %}
+            <a class="btn bg-yellow-200" href="{% url 'staff:order-analysis-detail' pk=analysis_orders.first.id %}">Go to {{ analysis_orders.first}}</a>
+        {% endif %}
         <a class="btn bg-primary" href="{% url 'staff:order-add-staff' pk=object.id %}">Assign staff</a>
 
         <div class="ml-auto"></div>
@@ -46,5 +38,23 @@
                 {% action-button action=to_next_status_url class="bg-secondary text-white" submit_text=btn_name csrf_token=csrf_token %}
             {% endwith %}
         {% endif %}
+
+    </div>
+
+    {% fragment as table_header %}
+    {% #table-cell header=True %}GUID{% /table-cell %}
+    {% #table-cell header=True %}Type{% /table-cell %}
+    {% #table-cell header=True %}Species{% /table-cell %}
+    {% #table-cell header=True %}Markers{% /table-cell %}
+    {% #table-cell header=True %}Location{% /table-cell %}
+    {% #table-cell header=True %}Date{% /table-cell %}
+    {% #table-cell header=True %}Volume{% /table-cell %}
+    {% endfragment %}
+
+    {% object-detail object=object %}
+
+    <h5 class="text-2xl my-5">Delivered Samples</h5>
+    <div class="bg-white p-4">
+        <p>{{ object.samples.count }} samples were delivered</p>
     </div>
 {% endblock %}

--- a/src/staff/views.py
+++ b/src/staff/views.py
@@ -172,6 +172,12 @@ class EquipmentOrderDetailView(StaffMixin, DetailView):
 class ExtractionOrderDetailView(StaffMixin, DetailView):
     model = ExtractionOrder
 
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        extraction_order = self.object
+        context["analysis_orders"] = extraction_order.analysis_orders.all()
+        return context
+
 
 class OrderExtractionSamplesListView(StaffMixin, SingleTableMixin, FilterView):
     table_pagination = False


### PR DESCRIPTION
Added button which reroutes the user to a related analysis order from the extraction order page. If there are multiple analysis orders connected to the extraction order, a drop down menu will be shown as in the image:

![image](https://github.com/user-attachments/assets/21bcad01-743c-4912-bd40-f68ff0612e52)

If only one analysis order is linked, a button is shown, and if no analysis order are linked to the extraction order, nothing is shown.