### PR TITLE
Made a workaround to not have a buggy upper flag in samples list.

### DIFF
--- a/src/staff/templates/staff/prioritise_flag.html
+++ b/src/staff/templates/staff/prioritise_flag.html
@@ -1,8 +1,3 @@
-<form method="post" action="{% url 'staff:order-extraction-samples' pk=record.order_id %}" style="display:inline;">
-    {% csrf_token %}
-    <input type="hidden" name="sample_id" value="{{ record.pk }}">
-    <button type="submit" title="Toggle prioritised">
-        {% csrf_token %}
-        <i class="fa-solid fa-flag {% if record.is_prioritised %}text-blue-500{% else %}text-gray-300{% endif %}"></i>
-    </button>
-</form>
+<button type="button" class="toggle-prioritise" data-sample-id="{{ record.pk }}" data-order-id="{{ record.order_id }}" title="Toggle prioritised">
+    <i class="fa-solid fa-flag {% if record.is_prioritised %}text-blue-500{% else %}text-gray-300{% endif %}"></i>
+</button>

--- a/src/staff/templates/staff/sample_filter.html
+++ b/src/staff/templates/staff/sample_filter.html
@@ -38,5 +38,22 @@
 
     {% render_table table %}
   </form>
+
+  <form id="prioritise-form" method="post" action="{% url 'staff:order-extraction-samples' pk=order.pk %}" style="display:none;">
+    {% csrf_token %}
+    <input type="hidden" name="sample_id" id="prioritise-sample-id">
+  </form>
 {% endif %}
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+      document.querySelectorAll('.toggle-prioritise').forEach(btn => {
+        btn.addEventListener('click', function () {
+          const sampleId = this.dataset.sampleId;
+          const form = document.getElementById('prioritise-form');
+          form.querySelector('#prioritise-sample-id').value = sampleId;
+          form.submit();
+        });
+      });
+    });
+    </script>
 {% endblock page-inner %}


### PR DESCRIPTION
Put the form for the flags outside of the generate genlab ids form to not disable the first row's flag. 