### PR TITLE
Only one button for generating genlab id and set as "processing"

### DIFF
--- a/src/genlab_bestilling/models.py
+++ b/src/genlab_bestilling/models.py
@@ -495,14 +495,6 @@ class ExtractionOrder(Order):
             if persist:
                 super().confirm_order()
 
-    def order_manually_checked(self) -> None:
-        """
-        Set the order as checked by the lab staff, generate a genlab id
-        """
-        self.internal_status = self.Status.CHECKED
-        self.status = self.OrderStatus.PROCESSING
-        self.save(update_fields=["internal_status", "status"])
-
     @transaction.atomic
     def order_selected_checked(
         self,

--- a/src/staff/templates/staff/extractionorder_detail.html
+++ b/src/staff/templates/staff/extractionorder_detail.html
@@ -45,17 +45,12 @@
             </form>
         {% endif %}
 
-        {% if object.status == object.OrderStatus.DELIVERED %}
-            {% url 'staff:order-manually-checked' pk=object.id as confirm_check_url %}
-            {% action-button action=confirm_check_url class="bg-secondary text-white" submit_text="Confirm - Order checked" csrf_token=csrf_token %}
-        {% endif %}
-
         {% if object.status != object.OrderStatus.DRAFT %}
             {% url 'staff:order-to-draft' pk=object.id as to_draft_url %}
             {% action-button action=to_draft_url class="bg-secondary text-white" submit_text="Convert to draft" csrf_token=csrf_token %}
         {% endif %}
 
-        {% if object.next_status %}
+        {% if object.status == object.OrderStatus.DELIVERED and object.internal_status == "checked" %}
             {% url 'staff:order-to-next-status' pk=object.id as to_next_status_url %}
             {% with "Set as "|add:object.next_status as btn_name %}
                 {% action-button action=to_next_status_url class="bg-secondary text-white" submit_text=btn_name csrf_token=csrf_token %}

--- a/src/staff/templates/staff/sample_filter.html
+++ b/src/staff/templates/staff/sample_filter.html
@@ -21,28 +21,29 @@
 
 {% block page-inner %}
 {% if order %}
-<div class="flex gap-5 mb-5">
-    <a class="btn bg-primary" href="../"><i class="fas fa-arrow-left"></i> back</a>
-    <a class="btn bg-yellow-500" href="{% url 'samples-csv' %}?order={{ order.pk }}"><i class="fas fa-download"></i> Download CSV</a>
-    <a class="btn bg-primary" href="{% url 'staff:order-extraction-samples-lab' order.pk %}"><i class="fas fa-flask"></i> Lab</a>
-</div>
+  <div class="flex gap-5 mb-5">
+      <a class="btn bg-primary" href="../"><i class="fas fa-arrow-left"></i> back</a>
+      <a class="btn bg-yellow-500" href="{% url 'samples-csv' %}?order={{ order.pk }}"><i class="fas fa-download"></i> Download CSV</a>
+      <a class="btn bg-primary" href="{% url 'staff:order-extraction-samples-lab' order.pk %}"><i class="fas fa-flask"></i> Lab</a>
+      {% if order.status == order.OrderStatus.DELIVERED and order.internal_status == "checked" %}
+        {% url 'staff:order-to-next-status' pk=order.pk as to_next_status_url %}
+        {% action-button action=to_next_status_url class="bg-secondary text-white" submit_text="Set as processing" csrf_token=csrf_token %}
+      {% endif %}
+  </div>
 
-<form method="post" action="{% url 'staff:generate-genlab-ids' pk=order.pk %}">
-    {% csrf_token %}
-    <input type="hidden" name="sort" value="{{ request.GET.sort|default:'' }}">
-    <button class="btn bg-blue-500 text-white mt-4" type="submit" name="generate_genlab_ids">
-        <i class="fa-solid fa-id-badge"></i> Generate genlab IDs
-    </button>
-
-    <div class="text-right text-sm text-red-500"> This page is under development. The genlab IDs will generate for all, and without sorting as per now. </div>
-
-    {% render_table table %}
+  <form method="post" action="{% url 'staff:generate-genlab-ids' pk=order.pk %}">
+      {% csrf_token %}
+      <input type="hidden" name="sort" value="{{ request.GET.sort|default:'' }}">
+      <button class="btn bg-blue-500 text-white mt-4" type="submit" name="generate_genlab_ids">
+          <i class="fa-solid fa-id-badge"></i> Generate genlab IDs
+      </button>
+      {% render_table table %}
   </form>
 
-  <form id="prioritise-form" method="post" action="{% url 'staff:order-extraction-samples' pk=order.pk %}" style="display:none;">
-    {% csrf_token %}
-    <input type="hidden" name="sample_id" id="prioritise-sample-id">
-  </form>
+    <form id="prioritise-form" method="post" action="{% url 'staff:order-extraction-samples' pk=order.pk %}" style="display:none;">
+      {% csrf_token %}
+      <input type="hidden" name="sample_id" id="prioritise-sample-id">
+    </form>
 {% endif %}
 <script>
     document.addEventListener("DOMContentLoaded", function () {
@@ -55,5 +56,5 @@
         });
       });
     });
-    </script>
-{% endblock page-inner %}
+</script>
+{% endblock %}

--- a/src/staff/urls.py
+++ b/src/staff/urls.py
@@ -12,7 +12,6 @@ from .views import (
     ExtractionPlateDetailView,
     ExtractionPlateListView,
     GenerateGenlabIDsView,
-    ManaullyCheckedOrderActionView,
     MarkAsSeenView,
     OrderAnalysisSamplesListView,
     OrderExtractionSamplesListView,
@@ -68,11 +67,6 @@ urlpatterns = [
         "orders/<int:pk>/to-next-status/",
         OrderToNextStatusActionView.as_view(),
         name="order-to-next-status",
-    ),
-    path(
-        "orders/<int:pk>/manually-checked/",
-        ManaullyCheckedOrderActionView.as_view(),
-        name="order-manually-checked",
     ),
     path(
         "<str:model_type>/<int:pk>/add-staff/",

--- a/src/staff/views.py
+++ b/src/staff/views.py
@@ -485,40 +485,6 @@ class UpdateInternalNote(StaffMixin, ActionView):
             return JsonResponse({"error": "Sample not found"}, status=404)
 
 
-class ManaullyCheckedOrderActionView(SingleObjectMixin, ActionView):
-    model = ExtractionOrder
-
-    def get_queryset(self) -> models.QuerySet[ExtractionOrder]:
-        return ExtractionOrder.objects.filter(status=Order.OrderStatus.DELIVERED)
-
-    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
-        self.object = self.get_object()
-        return super().post(request, *args, **kwargs)
-
-    def form_valid(self, form: Form) -> HttpResponse:
-        try:
-            # TODO: check state transition
-            self.object.order_manually_checked()
-            messages.add_message(
-                self.request,
-                messages.SUCCESS,
-                _("The order was checked, GenLab IDs will be generated"),
-            )
-        except Exception as e:
-            messages.error(self.request, f"Error: {str(e)}")
-
-        return super().form_valid(form)
-
-    def get_success_url(self) -> str:
-        return reverse_lazy(
-            f"staff:order-{self.object.get_type()}-detail",
-            kwargs={"pk": self.object.id},
-        )
-
-    def form_invalid(self, form: Form) -> HttpResponse:
-        return HttpResponseRedirect(self.get_success_url())
-
-
 class StaffEditView(StaffMixin, SingleObjectMixin, TemplateView):
     form_class = OrderStaffForm
     template_name = "staff/order_staff_edit.html"
@@ -640,7 +606,10 @@ class OrderToNextStatusActionView(SingleObjectMixin, ActionView):
         return super().form_valid(form)
 
     def get_success_url(self) -> str:
-        return reverse_lazy(f"staff:order-{self.object.get_type()}-list")
+        return reverse_lazy(
+            f"staff:order-{self.object.get_type()}-detail",
+            kwargs={"pk": self.object.pk},
+        )
 
     def form_invalid(self, form: Form) -> HttpResponse:
         return HttpResponseRedirect(self.get_success_url())


### PR DESCRIPTION
Only able to generate and set to "processing" from the samples page.

If an order has genlab ids and is converted to draft, it will be returned as delivered, and staff will have a button for setting it from delivered to processing. 

Currently no way of setting an order to "completed". Issue upcoming. 
The analysis and equipment pages are unaffected. 