### PR TITLE
Update logic for orders that have been converted to draft and delivered again dashboard

### DIFF
--- a/src/genlab_bestilling/models.py
+++ b/src/genlab_bestilling/models.py
@@ -320,6 +320,7 @@ class Order(PolymorphicModel):
 
     def to_draft(self) -> None:
         self.status = Order.OrderStatus.DRAFT
+        self.is_seen = False
         self.confirmed_at = None
         self.save()
 

--- a/src/staff/templatetags/order_tags.py
+++ b/src/staff/templatetags/order_tags.py
@@ -168,6 +168,7 @@ def assigned_orders_table(context: dict) -> dict:
                 Order.OrderStatus.DELIVERED,
             ],
             responsible_staff=user,
+            is_seen=True,
         )
         .select_related("genrequest")
         .annotate(


### PR DESCRIPTION
Set 'is_seen' to False  when converted to draft.

Order must be marked as "seen" to be shown in assigned orders (my orders).