### PR TITLE
Make dashboard table scrollable

### DIFF
--- a/src/staff/tables.py
+++ b/src/staff/tables.py
@@ -576,6 +576,8 @@ class UrgentOrderTable(StaffIDMixinTable, StatusMixinTable):
 
 
 class NewUnseenOrderTable(StaffIDMixinTable):
+    sticky_header = True
+
     seen = tables.TemplateColumn(
         verbose_name="",
         orderable=False,
@@ -619,6 +621,8 @@ class NewUnseenOrderTable(StaffIDMixinTable):
 
 
 class NewSeenOrderTable(StaffIDMixinTable):
+    sticky_header = True
+
     priority = tables.TemplateColumn(
         orderable=False,
         verbose_name="Priority",
@@ -668,6 +672,8 @@ class NewSeenOrderTable(StaffIDMixinTable):
 
 
 class AssignedOrderTable(StatusMixinTable, StaffIDMixinTable):
+    sticky_header = True
+
     priority = tables.TemplateColumn(
         orderable=False,
         verbose_name="Priority",
@@ -699,6 +705,8 @@ class AssignedOrderTable(StatusMixinTable, StaffIDMixinTable):
 
 
 class DraftOrderTable(StaffIDMixinTable):
+    sticky_header = True
+
     priority = tables.TemplateColumn(
         orderable=False,
         verbose_name="Priority",

--- a/src/staff/templates/staff/components/order_table.html
+++ b/src/staff/templates/staff/components/order_table.html
@@ -2,5 +2,7 @@
 
 <div class="rounded-md border bg-white p-4">
   <h4 class="text-2xl mb-4">{{ title }} ({{ count }})</h4>
-  {% render_table table %}
+  <div class="relative overflow-y-scroll{% if table.sticky_header %} max-h-96{% endif %}">
+    {% render_table table %}
+  </div>
 </div>

--- a/src/templates/django_tables2/header.html
+++ b/src/templates/django_tables2/header.html
@@ -1,25 +1,24 @@
-<thead {{ table.attrs.thead.as_html }}>
-    <tr>
+<thead class="{% if table.sticky_header %}sticky top-0{% endif %}" {{ table.attrs.thead.as_html }}>
+  <tr>
     {% for column in table.columns %}
-        <th {{ column.attrs.th.as_html }}>
-            {% if column.orderable %}
-                <a href="?{{ column.ext.next }}"
-                   class="inline-flex items-center gap-1">
-                    {{ column.header }}
-                    {% if column.is_ordered %}
-                        {% if "-" in column.order_by_alias %}
-                            <i class="fa-solid fa-sort-down text-gray-500"></i>
-                        {% else %}
-                            <i class="fa-solid fa-sort-up text-gray-500"></i>
-                        {% endif %}
-                    {% else %}
-                        <i class="fa-solid fa-sort text-gray-400 hover:text-black"></i>
-                    {% endif %}
-                </a>
+      <th {{ column.attrs.th.as_html }}>
+        {% if column.orderable %}
+          <a href="?{{ column.ext.next }}" class="inline-flex items-center gap-1">
+            {{ column.header }}
+            {% if column.is_ordered %}
+              {% if '-' in column.order_by_alias %}
+                <i class="fa-solid fa-sort-down text-gray-500"></i>
+              {% else %}
+                <i class="fa-solid fa-sort-up text-gray-500"></i>
+              {% endif %}
             {% else %}
-                {{ column.header }}
+              <i class="fa-solid fa-sort text-gray-400 hover:text-black"></i>
             {% endif %}
-        </th>
+          </a>
+        {% else %}
+          {{ column.header }}
+        {% endif %}
+      </th>
     {% endfor %}
-    </tr>
+  </tr>
 </thead>


### PR DESCRIPTION
- Adds option to tables to make the table header sticky.
- Makes all tables sticky except the urgent order table
- Urgent order table is excluded as the orders are urgent, they should all be visible immediately.

https://github.com/user-attachments/assets/42d05986-1833-484b-9d6a-20dc853c7649

