### PR TITLE
Add database url to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 POSTGRES_PASSWORD=postgres
 DJANGO_SECRET_KEY=secret
+DATABASE_URL=postgis://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres?sslmode=disable
 
 # Generate a client id/client secret on keycloack
 OIDC_CLIENT_ID=


### PR DESCRIPTION
Adds `DATABASE_URL` to `.env.example` so that the mypy extension in VSCode doesn't crash.

Could be nice to have in the case where someone doesn't know that the missing env-variable is the reason mypy breaks on VSCode.

