### PR TITLE
Fix N + 1 query

### DIFF
--- a/src/genlab_bestilling/api/constants.py
+++ b/src/genlab_bestilling/api/constants.py
@@ -101,6 +101,8 @@ SAMPLE_CSV_FIELDS_BY_AREA = {
         "genlab_id",
         "fish_id",
         "guid",
+        "order",
+        "analysis_orders",
         "river",
         "location.name",
         "under_locality",

--- a/src/genlab_bestilling/api/serializers.py
+++ b/src/genlab_bestilling/api/serializers.py
@@ -134,8 +134,15 @@ class SampleCSVSerializer(serializers.ModelSerializer):
         return obj.fish_id or "-"
 
     def get_analysis_orders(self, obj: Sample) -> list[str]:
-        if obj.order and obj.order.analysis_orders.exists():
-            return [str(anl.id) for anl in obj.order.analysis_orders.all()]
+        if not obj.order:
+            return []
+
+        analysis_orders = obj.order.analysis_orders.all()
+        # Return all analysis order IDs as strings
+        # only if there is exactly one analysis order, else return empty list.
+        # This is to ensure no duplicate rows in staffs common sheet
+        if analysis_orders.count() == 1:
+            return [str(analysis_orders.first().id)]
         return []
 
     def get_project(self, obj: Sample) -> str:

--- a/src/genlab_bestilling/api/views.py
+++ b/src/genlab_bestilling/api/views.py
@@ -4,7 +4,7 @@ import uuid
 from typing import Any
 
 from django.db import transaction
-from django.db.models import QuerySet
+from django.db.models import Prefetch, QuerySet
 from django.http import HttpResponse
 from django.views import View
 from drf_spectacular.utils import extend_schema
@@ -36,6 +36,7 @@ from ..filters import (
     SpeciesFilter,
 )
 from ..models import (
+    AnalysisOrder,
     AnalysisType,
     ExtractionOrder,
     Location,
@@ -189,6 +190,12 @@ class SampleViewset(ModelViewSet, SampleCSVExportMixin):
                 "order__genrequest",
                 "order__genrequest__area",
                 "location",
+            )
+            .prefetch_related(
+                Prefetch(
+                    "order__analysis_orders",
+                    queryset=AnalysisOrder.objects.only("id"),
+                )
             )
             .order_by("genlab_id", "type")
         )


### PR DESCRIPTION
Refactor logic to choose when analysis_orders are shown in the CSV file.
The new solution only shows analysis order in the CSV file if there is a one-to-one relation between extraction and analysis. This is to avoid duplicate rows in the staffs common sheet. The solution is discussed with Emily (the teams designer), and concluded to be the best solution for now.

Add extraction order and analysis order to "elvemusling" CSV.