### PR TITLE
Remove delete button when converted to draft

### DIFF
--- a/src/genlab_bestilling/templates/genlab_bestilling/analysisorder_detail.html
+++ b/src/genlab_bestilling/templates/genlab_bestilling/analysisorder_detail.html
@@ -44,7 +44,9 @@
         {% url 'genrequest-order-clone' genrequest_id=object.genrequest_id pk=object.id as clone_order_url %}
         {% action-button action=confirm_order_url class="btn custom_order_button" submit_text="Deliver order" csrf_token=csrf_token %}
         {% action-button action=clone_order_url class="btn custom_order_button" submit_text="Clone Order" csrf_token=csrf_token %}
+        {% if all_samples_have_no_genlab_id %}
         <a class="btn custom_order_button_red" href="{% url 'genrequest-analysis-delete' genrequest_id=object.genrequest_id pk=object.id %}">Delete</a>
+        {% endif %}
         {% elif object.status == object.OrderStatus.DELIVERED %}
         <a class="btn custom_order_button" href="{% url 'genrequest-analysis-samples' genrequest_id=object.genrequest_id pk=object.id %}">Samples</a>
         {% endif %}

--- a/src/genlab_bestilling/templates/genlab_bestilling/extractionorder_detail.html
+++ b/src/genlab_bestilling/templates/genlab_bestilling/extractionorder_detail.html
@@ -24,8 +24,9 @@
 
             {% url 'genrequest-order-confirm' genrequest_id=object.genrequest_id pk=object.id as confirm_order_url %}
             {% action-button action=confirm_order_url class="btn custom_order_button" submit_text="Deliver order" csrf_token=csrf_token %}
-
+            {% if all_samples_have_no_genlab_id %}
             <a class="btn custom_order_button_red" href="{% url 'genrequest-analysis-delete' genrequest_id=object.genrequest_id pk=object.id %}">Delete</a>
+            {% endif %}
         {% endif %}
 
         <a class="btn custom_order_button" href="{% url 'genrequest-extraction-samples' genrequest_id=object.genrequest_id pk=object.id %}">Samples</a>

--- a/src/genlab_bestilling/views.py
+++ b/src/genlab_bestilling/views.py
@@ -475,6 +475,15 @@ class AnalysisOrderDetailView(GenrequestNestedMixin, DetailView):
             .prefetch_related("sample_markers", "markers")
         )
 
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        order = self.object
+        all_samples_have_no_genlab_id = not order.samples.exclude(
+            genlab_id__isnull=True
+        ).exists()
+        context["all_samples_have_no_genlab_id"] = all_samples_have_no_genlab_id
+        return context
+
 
 class ExtractionOrderDetailView(GenrequestNestedMixin, DetailView):
     model = ExtractionOrder
@@ -498,6 +507,15 @@ class ExtractionOrderDetailView(GenrequestNestedMixin, DetailView):
             ),
             (str(self.object), ""),
         ]
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        order = self.object
+        all_samples_have_no_genlab_id = not order.samples.exclude(
+            genlab_id__isnull=True
+        ).exists()
+        context["all_samples_have_no_genlab_id"] = all_samples_have_no_genlab_id
+        return context
 
 
 class GenrequestOrderDeleteView(GenrequestNestedMixin, DeleteView):


### PR DESCRIPTION
If an order is started (has genlab ids) it cannot be deleted by researchers. 
Equipment orders can still be deleted by researchers if converted to draft.